### PR TITLE
Fix browser "Connection is closed" issue when using browser authentication

### DIFF
--- a/target_snowflake/connector.py
+++ b/target_snowflake/connector.py
@@ -192,11 +192,11 @@ class SnowflakeConnector(SQLConnector):
             connect_args=connect_args,
             echo=False,
         )
-        connection = engine.connect()
-        db_names = [db[1] for db in connection.execute(text("SHOW DATABASES;")).fetchall()]
-        if self.config["database"] not in db_names:
-            msg = f"Database '{self.config['database']}' does not exist or the user/role doesn't have access to it."
-            raise Exception(msg)  # noqa: TRY002
+        with engine.connect() as conn:
+            db_names = [db[1] for db in conn.execute(text("SHOW DATABASES;")).fetchall()]
+            if self.config["database"] not in db_names:
+                msg = f"Database '{self.config['database']}' does not exist or the user/role doesn't have access to it."
+                raise Exception(msg)  # noqa: TRY002
         return engine
 
     def prepare_column(


### PR DESCRIPTION
The purpose of this PR is to solve the issue detailed [here](https://github.com/MeltanoLabs/target-snowflake/issues/225).

The issue was related to the fact that the `engine.connect()` method was not always being used as a context manager, not allowing all closing/disposing method to  